### PR TITLE
App Lock: device auth + PIN, backoff, and UX polish

### DIFF
--- a/bitchat/Info.plist
+++ b/bitchat/Info.plist
@@ -39,6 +39,8 @@
 	<string>bitchat uses the camera to scan QR codes to verify peers.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>bitchat uses your approximate location to compute local geohash channels for optional public chats. Exact GPS is never shared.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Unlock the app using Face ID.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/bitchat/Services/AppLock/AppLockManager.swift
+++ b/bitchat/Services/AppLock/AppLockManager.swift
@@ -217,6 +217,12 @@ final class AppLockManager: ObservableObject {
 
     func biometryType() -> BiometryType { localAuth.biometryType() }
 
+    func deviceAuthAvailable() -> Bool { localAuth.canEvaluateOwnerAuth() }
+
+    func hasPINConfigured() -> Bool {
+        return keychain.getAppLockSecret(key: pinSaltKey) != nil && keychain.getAppLockSecret(key: pinHashKey) != nil
+    }
+
     func panicClear() {
         clearPIN()
         setEnabled(false)

--- a/bitchat/Services/AppLock/AppLockManager.swift
+++ b/bitchat/Services/AppLock/AppLockManager.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Combine
+import Security
+import CryptoKit
+
+final class AppLockManager: ObservableObject {
+    enum Method: String { case off, deviceAuth, pin }
+
+    struct ConfigKeys {
+        static let enabled = "applock.enabled"
+        static let method = "applock.method"
+        static let grace = "applock.gracePeriodSeconds"
+        static let lockOnLaunch = "applock.lockOnLaunch"
+        static let lastBackgroundAt = "applock.lastBackgroundAt"
+    }
+
+    private let keychain: KeychainManagerProtocol
+    private let localAuth: LocalAuthProviderProtocol
+    private let defaults: UserDefaults
+
+    @Published private(set) var isLocked: Bool = false
+    @Published var method: Method
+    @Published var isEnabled: Bool
+    @Published var gracePeriodSeconds: Int
+    @Published var lockOnLaunch: Bool
+
+    private let pinSaltKey = "applock_pin_salt"
+    private let pinHashKey = "applock_pin_hash"
+
+    init(keychain: KeychainManagerProtocol = KeychainManager(),
+         localAuth: LocalAuthProviderProtocol = LocalAuthProvider(),
+         defaults: UserDefaults = .standard) {
+        self.keychain = keychain
+        self.localAuth = localAuth
+        self.defaults = defaults
+
+        self.isEnabled = defaults.bool(forKey: ConfigKeys.enabled)
+        self.method = Method(rawValue: defaults.string(forKey: ConfigKeys.method) ?? Method.off.rawValue) ?? .off
+        let grace = defaults.object(forKey: ConfigKeys.grace) as? Int
+        self.gracePeriodSeconds = grace ?? 0
+        self.lockOnLaunch = defaults.bool(forKey: ConfigKeys.lockOnLaunch)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+        defaults.set(enabled, forKey: ConfigKeys.enabled)
+        if !enabled { isLocked = false }
+    }
+
+    func setMethod(_ m: Method) {
+        method = m
+        defaults.set(m.rawValue, forKey: ConfigKeys.method)
+    }
+
+    func setGrace(_ seconds: Int) {
+        gracePeriodSeconds = seconds
+        defaults.set(seconds, forKey: ConfigKeys.grace)
+    }
+
+    func setLockOnLaunch(_ v: Bool) {
+        lockOnLaunch = v
+        defaults.set(v, forKey: ConfigKeys.lockOnLaunch)
+    }
+
+    func onDidEnterBackground() {
+        defaults.set(Date(), forKey: ConfigKeys.lastBackgroundAt)
+        // Cancel any pending auth prompt
+        localAuth.invalidate()
+    }
+
+    func onDidBecomeActive() {
+        guard isEnabled, method != .off else { return }
+        if lockOnLaunch && didJustColdLaunch() { isLocked = true; return }
+        if shouldLockOnActivate() { isLocked = true }
+    }
+
+    private func didJustColdLaunch() -> Bool {
+        // If no last background time exists, treat as cold launch
+        return defaults.object(forKey: ConfigKeys.lastBackgroundAt) == nil
+    }
+
+    func shouldLockOnActivate() -> Bool {
+        guard gracePeriodSeconds > 0 else { return true }
+        guard let last = defaults.object(forKey: ConfigKeys.lastBackgroundAt) as? Date else { return true }
+        return Date().timeIntervalSince(last) >= TimeInterval(gracePeriodSeconds)
+    }
+
+    func lockNow() { if isEnabled && method != .off { isLocked = true } }
+
+    func unlockWithDeviceAuth(reason: String = "Unlock bitchat") {
+        localAuth.evaluateOwnerAuth(reason: reason) { [weak self] success, err in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if success {
+                    self.isLocked = false
+                } else {
+                    if let err = err { SecureLogger.error(err, context: "AppLock device auth failed", category: .security) }
+                }
+            }
+        }
+    }
+
+    func setPIN(_ pin: String) {
+        guard let data = pin.data(using: .utf8) else { return }
+        let salt = Self.randomData(count: 16)
+        var combined = Data(salt)
+        combined.append(data)
+        let hash = Self.sha256(data: combined)
+        _ = keychain.saveAppLockSecret(salt, key: pinSaltKey)
+        _ = keychain.saveAppLockSecret(hash, key: pinHashKey)
+        SecureLogger.info("AppLock PIN set", category: .security)
+    }
+
+    func clearPIN() {
+        _ = keychain.deleteAppLockSecret(key: pinSaltKey)
+        _ = keychain.deleteAppLockSecret(key: pinHashKey)
+        SecureLogger.info("AppLock PIN cleared", category: .security)
+    }
+
+    func validate(pin: String) -> Bool {
+        guard let salt = keychain.getAppLockSecret(key: pinSaltKey),
+              let stored = keychain.getAppLockSecret(key: pinHashKey),
+              let data = pin.data(using: .utf8) else { return false }
+        var combined = Data(salt)
+        combined.append(data)
+        let computed = Self.sha256(data: combined)
+        let match = constantTimeEqual(computed, stored)
+        if match { isLocked = false }
+        return match
+    }
+
+    func panicClear() {
+        clearPIN()
+        setEnabled(false)
+        setMethod(.off)
+        isLocked = false
+    }
+
+    // MARK: - Utils
+    private static func randomData(count: Int) -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        if status != errSecSuccess { return Data((0..<count).map { _ in UInt8.random(in: 0...255) }) }
+        return Data(bytes)
+    }
+
+    private static func sha256(data: Data) -> Data {
+        let digest = SHA256.hash(data: data)
+        return Data(digest)
+    }
+
+    private func constantTimeEqual(_ a: Data, _ b: Data) -> Bool {
+        guard a.count == b.count else { return false }
+        var diff: UInt8 = 0
+        for i in 0..<a.count { diff |= a[i] ^ b[i] }
+        return diff == 0
+    }
+}

--- a/bitchat/Services/AppLock/AppLockManager.swift
+++ b/bitchat/Services/AppLock/AppLockManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import Security
 import CryptoKit
+import BitLogger
 
 final class AppLockManager: ObservableObject {
     enum Method: String { case off, deviceAuth, pin }

--- a/bitchat/Services/AppLock/LocalAuthProvider.swift
+++ b/bitchat/Services/AppLock/LocalAuthProvider.swift
@@ -1,0 +1,43 @@
+import Foundation
+import LocalAuthentication
+
+protocol LocalAuthProviderProtocol {
+    func canEvaluateOwnerAuth() -> Bool
+    func evaluateOwnerAuth(reason: String, completion: @escaping (Bool, Error?) -> Void)
+    func invalidate()
+}
+
+final class LocalAuthProvider: LocalAuthProviderProtocol {
+    private var context: LAContext?
+
+    private func freshContext() -> LAContext {
+        // Create a fresh LAContext per attempt, per Apple guidance
+        let ctx = LAContext()
+        // Optionally reduce re-prompts for brief periods
+        if #available(iOS 11.0, macOS 10.13.2, *) {
+            ctx.touchIDAuthenticationAllowableReuseDuration = 8 // seconds
+        }
+        return ctx
+    }
+
+    func canEvaluateOwnerAuth() -> Bool {
+        let ctx = freshContext()
+        var err: NSError?
+        let can = ctx.canEvaluatePolicy(.deviceOwnerAuthentication, error: &err)
+        return can
+    }
+
+    func evaluateOwnerAuth(reason: String, completion: @escaping (Bool, Error?) -> Void) {
+        let ctx = freshContext()
+        self.context = ctx
+        ctx.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, error in
+            completion(success, error)
+        }
+    }
+
+    func invalidate() {
+        context?.invalidate()
+        context = nil
+    }
+}
+

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -246,10 +246,14 @@ struct AppInfoView: View {
                     }
                     SecureField("enter pin", text: $pin1)
                         .textFieldStyle(.roundedBorder)
+                        #if os(iOS)
                         .keyboardType(.numberPad)
+                        #endif
                     SecureField("confirm pin", text: $pin2)
                         .textFieldStyle(.roundedBorder)
+                        #if os(iOS)
                         .keyboardType(.numberPad)
+                        #endif
                     if let err = pinError {
                         Text(err).foregroundColor(.red).font(.system(size: 12, design: .monospaced))
                     }

--- a/bitchat/Views/AppInfoView.swift
+++ b/bitchat/Views/AppInfoView.swift
@@ -258,11 +258,25 @@ struct AppInfoView: View {
                         Text(err).foregroundColor(.red).font(.system(size: 12, design: .monospaced))
                     }
                     Button("save") {
+                        // Basic PIN strength and validity checks
                         if pin1.count < 4 || pin1.count > 8 { pinError = "pin must be 4–8 digits"; return }
+                        // digits only
+                        if !pin1.allSatisfy({ $0.isNumber }) { pinError = "pin must contain only digits"; return }
+                        // all same digits
+                        if let f = pin1.first, pin1 == String(repeating: f, count: pin1.count) {
+                            pinError = "pin cannot be all same digits"; return
+                        }
+                        // common bad pins
+                        let badPins: Set<String> = ["1234","4321","0000","1111","2222","9999","1212","1122"]
+                        if badPins.contains(pin1) { pinError = "pin is too common"; return }
                         guard pin1 == pin2 else { pinError = "pins do not match"; return }
-                        appLock.setPIN(pin1)
-                        pin1 = ""; pin2 = ""; pinError = nil
-                        showSetPIN = false
+
+                        if appLock.setPIN(pin1) {
+                            pin1 = ""; pin2 = ""; pinError = nil
+                            showSetPIN = false
+                        } else {
+                            pinError = "failed to save pin"
+                        }
                     }
                     .buttonStyle(.borderedProminent)
                 }

--- a/bitchat/Views/AppLockView.swift
+++ b/bitchat/Views/AppLockView.swift
@@ -64,9 +64,10 @@ struct AppLockView: View {
                             .disabled(wait > 0)
                             .buttonStyle(.plain)
                             .foregroundColor(wait > 0 ? .gray : .blue)
-                            Button("Use Device") { appLock.unlockWithDeviceAuth() }
+                            Button(appLock.biometryType() == .faceID ? "Use Face ID" : (appLock.biometryType() == .touchID ? "Use Touch ID" : "Use Device")) { appLock.unlockWithDeviceAuth() }
                                 .buttonStyle(.plain)
                                 .foregroundColor(.blue)
+                                .accessibilityLabel(appLock.biometryType() == .faceID ? "Use Face ID to unlock" : (appLock.biometryType() == .touchID ? "Use Touch ID to unlock" : "Use device authentication to unlock"))
                         }
                     }
                     .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in

--- a/bitchat/Views/AppLockView.swift
+++ b/bitchat/Views/AppLockView.swift
@@ -27,7 +27,9 @@ struct AppLockView: View {
                         SecureField("Enter PIN", text: $pinInput)
                             .textFieldStyle(.roundedBorder)
                             .frame(maxWidth: 240)
+                            #if os(iOS)
                             .keyboardType(.numberPad)
+                            #endif
                         HStack(spacing: 12) {
                             Button("Unlock") {
                                 let ok = appLock.validate(pin: pinInput)
@@ -55,4 +57,3 @@ struct AppLockView: View {
         .accessibilityIdentifier("AppLockView")
     }
 }
-

--- a/bitchat/Views/AppLockView.swift
+++ b/bitchat/Views/AppLockView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct AppLockView: View {
+    @EnvironmentObject var appLock: AppLockManager
+    @Environment(\.colorScheme) var colorScheme
+    @State private var pinInput: String = ""
+    @State private var authError: String? = nil
+
+    private var textColor: Color { colorScheme == .dark ? .green : Color(red: 0, green: 0.5, blue: 0) }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(colorScheme == .dark ? 0.9 : 0.92).ignoresSafeArea()
+            VStack(spacing: 16) {
+                Text("bitchat")
+                    .font(.system(size: 24, weight: .bold, design: .monospaced))
+                    .foregroundColor(textColor)
+
+                switch appLock.method {
+                case .deviceAuth:
+                    Button("Unlock") { appLock.unlockWithDeviceAuth() }
+                        .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                        .foregroundColor(.blue)
+                        .buttonStyle(.plain)
+                case .pin:
+                    VStack(spacing: 8) {
+                        SecureField("Enter PIN", text: $pinInput)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: 240)
+                            .keyboardType(.numberPad)
+                        HStack(spacing: 12) {
+                            Button("Unlock") {
+                                let ok = appLock.validate(pin: pinInput)
+                                if !ok { authError = "Incorrect PIN"; pinInput = "" }
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundColor(.blue)
+                            Button("Use Device") { appLock.unlockWithDeviceAuth() }
+                                .buttonStyle(.plain)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                case .off:
+                    EmptyView()
+                }
+
+                if let err = authError {
+                    Text(err)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.red)
+                }
+            }
+            .padding()
+        }
+        .accessibilityIdentifier("AppLockView")
+    }
+}
+

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
     @State private var textFieldSelection: NSRange? = nil
     @FocusState private var isTextFieldFocused: Bool
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.scenePhase) private var scenePhase
     @State private var showPeerList = false
     @State private var showSidebar = false
     @State private var sidebarDragOffset: CGFloat = 0
@@ -164,6 +165,12 @@ struct ContentView: View {
                 if appLock.isEnabled && appLock.method != .off && appLock.isLocked {
                     AppLockView()
                         .environmentObject(appLock)
+                }
+
+                // Privacy snapshot overlay for app switcher when not active
+                if scenePhase != .active {
+                    Color.black.opacity(colorScheme == .dark ? 0.9 : 0.92)
+                        .ignoresSafeArea()
                 }
             }
         }

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     // MARK: - Properties
     
     @EnvironmentObject var viewModel: ChatViewModel
+    @EnvironmentObject var appLock: AppLockManager
     @ObservedObject private var locationManager = LocationChannelManager.shared
     @ObservedObject private var bookmarks = GeohashBookmarksStore.shared
     @ObservedObject private var notesCounter = LocationNotesCounter.shared
@@ -158,6 +159,12 @@ struct ContentView: View {
                     return showSidebar ? -dragOffset : width - dragOffset
                 }())
                 .animation(.easeInOut(duration: TransportConfig.uiAnimationSidebarSeconds), value: showSidebar)
+
+                // App Lock overlay gates UI
+                if appLock.isEnabled && appLock.method != .off && appLock.isLocked {
+                    AppLockView()
+                        .environmentObject(appLock)
+                }
             }
         }
         #if os(macOS)

--- a/bitchat/Views/ContentView.swift
+++ b/bitchat/Views/ContentView.swift
@@ -1101,6 +1101,8 @@ struct ContentView: View {
                 .onTapGesture(count: 3) {
                     // PANIC: Triple-tap to clear all data
                     viewModel.panicClearAllData()
+                    // Also clear app lock state to avoid locking user out
+                    appLock.panicClear()
                 }
                 .onTapGesture(count: 1) {
                     // Single tap for app info

--- a/bitchatTests/AppLockTests.swift
+++ b/bitchatTests/AppLockTests.swift
@@ -1,12 +1,14 @@
 import XCTest
 @testable import bitchat
 
+@MainActor
 final class AppLockTests: XCTestCase {
     final class MockAuth: LocalAuthProviderProtocol {
         var canEvaluate = true
         var nextResult: (Bool, Error?) = (true, nil)
         func canEvaluateOwnerAuth() -> Bool { canEvaluate }
-        func evaluateOwnerAuth(reason: String, completion: @escaping (Bool, Error?) -> Void) { completion(nextResult.0, nextResult.1) }
+        func evaluateOwnerAuth(reason: String, fallbackTitle: String?, completion: @escaping (Bool, Error?) -> Void) { completion(nextResult.0, nextResult.1) }
+        func biometryType() -> BiometryType { .none }
         func invalidate() {}
     }
 

--- a/bitchatTests/AppLockTests.swift
+++ b/bitchatTests/AppLockTests.swift
@@ -65,9 +65,8 @@ final class AppLockTests: XCTestCase {
         mgr.setEnabled(true)
         mgr.setMethod(.pin)
         mgr.lockNow()
-        mgr.setPIN("1234")
+        XCTAssertTrue(mgr.setPIN("1234"))
         XCTAssertTrue(mgr.validate(pin: "1234"))
         XCTAssertFalse(mgr.validate(pin: "9999"))
     }
 }
-

--- a/bitchatTests/AppLockTests.swift
+++ b/bitchatTests/AppLockTests.swift
@@ -69,4 +69,47 @@ final class AppLockTests: XCTestCase {
         XCTAssertTrue(mgr.validate(pin: "1234"))
         XCTAssertFalse(mgr.validate(pin: "9999"))
     }
+
+    func testBackoffSchedule() {
+        let kc = MockKeychain()
+        let auth = MockAuth()
+        let defaults = UserDefaults(suiteName: "test.applock.\(UUID().uuidString)")!
+        let mgr = AppLockManager(keychain: kc, localAuth: auth, defaults: defaults)
+        mgr.setEnabled(true)
+        mgr.setMethod(.pin)
+        XCTAssertTrue(mgr.setPIN("1234"))
+        mgr.lockNow()
+
+        // 4 failures: under threshold, no wait
+        for _ in 0..<4 { _ = mgr.validate(pin: "0000") }
+        var avail = mgr.canAttemptPIN()
+        XCTAssertTrue(avail.allowed)
+
+        // 5th failure: start backoff ~30s
+        _ = mgr.validate(pin: "0000")
+        avail = mgr.canAttemptPIN()
+        XCTAssertFalse(avail.allowed)
+        XCTAssertGreaterThanOrEqual(Int(avail.wait), 29)
+
+        // Simulate time passing by overwriting nextAllowedAt to now
+        // NOTE: Using internal helper via public API by setting successful validate after wait cleared
+    }
+
+    func testBackoffResetsOnSuccess() {
+        let kc = MockKeychain()
+        let auth = MockAuth()
+        let defaults = UserDefaults(suiteName: "test.applock.\(UUID().uuidString)")!
+        let mgr = AppLockManager(keychain: kc, localAuth: auth, defaults: defaults)
+        mgr.setEnabled(true)
+        mgr.setMethod(.pin)
+        XCTAssertTrue(mgr.setPIN("1234"))
+        mgr.lockNow()
+        for _ in 0..<6 { _ = mgr.validate(pin: "0000") }
+        XCTAssertFalse(mgr.canAttemptPIN().allowed)
+        // Now succeed and ensure counters clear
+        // Force allow by simulating wait elapsed with sleep(1) + assume schedule minimal
+        // We just test that after success, allowed returns true again
+        _ = mgr.validate(pin: "1234")
+        XCTAssertTrue(mgr.canAttemptPIN().allowed)
+    }
 }

--- a/bitchatTests/AppLockTests.swift
+++ b/bitchatTests/AppLockTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import bitchat
+
+final class AppLockTests: XCTestCase {
+    final class MockAuth: LocalAuthProviderProtocol {
+        var canEvaluate = true
+        var nextResult: (Bool, Error?) = (true, nil)
+        func canEvaluateOwnerAuth() -> Bool { canEvaluate }
+        func evaluateOwnerAuth(reason: String, completion: @escaping (Bool, Error?) -> Void) { completion(nextResult.0, nextResult.1) }
+        func invalidate() {}
+    }
+
+    final class MockKeychain: KeychainManagerProtocol {
+        var store: [String: Data] = [:]
+        func saveIdentityKey(_ keyData: Data, forKey key: String) -> Bool { false }
+        func getIdentityKey(forKey key: String) -> Data? { nil }
+        func deleteIdentityKey(forKey key: String) -> Bool { true }
+        func deleteAllKeychainData() -> Bool { store.removeAll(); return true }
+        func secureClear(_ data: inout Data) { data.removeAll() }
+        func secureClear(_ string: inout String) { string.removeAll() }
+        func verifyIdentityKeyExists() -> Bool { false }
+        func saveAppLockSecret(_ data: Data, key: String) -> Bool { store[key] = data; return true }
+        func getAppLockSecret(key: String) -> Data? { store[key] }
+        func deleteAppLockSecret(key: String) -> Bool { store.removeValue(forKey: key) != nil }
+    }
+
+    func testGraceAndLockOnActivate() {
+        let kc = MockKeychain()
+        let auth = MockAuth()
+        let defaults = UserDefaults(suiteName: "test.applock.\(UUID().uuidString)")!
+        let mgr = AppLockManager(keychain: kc, localAuth: auth, defaults: defaults)
+
+        mgr.setEnabled(true)
+        mgr.setMethod(.deviceAuth)
+        mgr.setGrace(30)
+        // Simulate background now
+        mgr.onDidEnterBackground()
+        // Within grace, should not lock
+        mgr.onDidBecomeActive()
+        XCTAssertFalse(mgr.isLocked)
+        // Force grace expiry
+        defaults.set(Date(timeIntervalSinceNow: -60), forKey: AppLockManager.ConfigKeys.lastBackgroundAt)
+        mgr.onDidBecomeActive()
+        XCTAssertTrue(mgr.isLocked)
+    }
+
+    func testLockOnLaunch() {
+        let kc = MockKeychain()
+        let auth = MockAuth()
+        let defaults = UserDefaults(suiteName: "test.applock.\(UUID().uuidString)")!
+        let mgr = AppLockManager(keychain: kc, localAuth: auth, defaults: defaults)
+        mgr.setEnabled(true)
+        mgr.setMethod(.deviceAuth)
+        mgr.setLockOnLaunch(true)
+        // No lastBackgroundAt => cold launch => locked
+        mgr.onDidBecomeActive()
+        XCTAssertTrue(mgr.isLocked)
+    }
+
+    func testPINSetAndValidate() {
+        let kc = MockKeychain()
+        let auth = MockAuth()
+        let defaults = UserDefaults(suiteName: "test.applock.\(UUID().uuidString)")!
+        let mgr = AppLockManager(keychain: kc, localAuth: auth, defaults: defaults)
+        mgr.setEnabled(true)
+        mgr.setMethod(.pin)
+        mgr.lockNow()
+        mgr.setPIN("1234")
+        XCTAssertTrue(mgr.validate(pin: "1234"))
+        XCTAssertFalse(mgr.validate(pin: "9999"))
+    }
+}
+

--- a/bitchatTests/Mocks/MockKeychain.swift
+++ b/bitchatTests/Mocks/MockKeychain.swift
@@ -43,4 +43,18 @@ final class MockKeychain: KeychainManagerProtocol {
     func verifyIdentityKeyExists() -> Bool {
         storage["identity_noiseStaticKey"] != nil
     }
+
+    // MARK: - App Lock Secrets
+    func saveAppLockSecret(_ data: Data, key: String) -> Bool {
+        storage["applock::\(key)"] = data
+        return true
+    }
+
+    func getAppLockSecret(key: String) -> Data? {
+        storage["applock::\(key)"]
+    }
+
+    func deleteAppLockSecret(key: String) -> Bool {
+        storage.removeValue(forKey: "applock::\(key)") != nil
+    }
 }


### PR DESCRIPTION
This PR adds an App Lock feature aligned with Apple best practices for modern SwiftUI apps on iOS/macOS.

Highlights
- Device auth via LocalAuthentication (`.deviceOwnerAuthentication`) with passcode fallback
- Optional app PIN with salted SHA-256 (CryptoKit), ThisDeviceOnly keychain class
- Full-screen overlay gates content (not login), no custom biometric UI
- Lifecycle hooks and snapshot protection to obscure app switcher previews
- PIN backoff: progressive delays after 5 failures (30s→60s→2m→4m→8m, cap 15m), persisted + hourly decay
- Accessibility and UX: countdown, warning haptic (iOS), VoiceOver announcement, biometry-specific labels
- Panic mode clears App Lock state to prevent post-wipe lockout
- Info.plist: adds NSFaceIDUsageDescription

Structure
- Core service: `AppLockManager` (@MainActor) + `LocalAuthProvider` wrapper
- Keychain helpers for App Lock secrets (ThisDeviceOnly)
- Overlay: `AppLockView` (gates UI) and settings in `AppInfoView`
- Tests: `AppLockTests` for core flows and backoff

Notes
- Device auth remains primary/unthrottled; PIN throttled only
- No default auto-wipe; manual panic remains
- If device auth unavailable and PIN exists, PIN fallback is shown; otherwise guidance is shown

Follow-ups (optional)
- Add a “Lock Now” action
- Expand weak-PIN heuristics
- Localization of strings (planned in a future PR)

Thanks!
